### PR TITLE
Improve handling of change notifications.

### DIFF
--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -38,12 +38,8 @@ async fn account_signup() -> Result<()> {
     let ClientKey(signing_key, _, _) = &key;
     let expected_signing_key = *signing_key;
 
-    println!("Trying to create account");
-
-    let credentials =
+    let (credentials, _disc_cache) =
         create_account(server, destination, name, key, cache_dir).await?;
-
-    println!("After creating account {}", expected_keystore.exists());
 
     assert_eq!(expected_keystore, credentials.keystore_file);
     assert!(expected_keystore.is_file());

--- a/workspace/client/src/signup.rs
+++ b/workspace/client/src/signup.rs
@@ -38,7 +38,7 @@ pub async fn create_account(
     name: Option<String>,
     key: ClientKey,
     cache_dir: PathBuf,
-) -> Result<ClientCredentials> {
+) -> Result<(ClientCredentials, FileCache)> {
     if !destination.is_dir() {
         return Err(Error::NotDirectory(destination));
     }
@@ -72,7 +72,7 @@ pub async fn create_account(
         address,
     };
 
-    Ok(account)
+    Ok((account, cache))
 }
 
 /// Create a signing key pair and compute the address.
@@ -119,7 +119,7 @@ pub fn signup(
 
     let prompt = Some("Are you sure (y/n)? ");
     if read_flag(prompt)? {
-        let account = run_blocking(create_account(
+        let (account, _) = run_blocking(create_account(
             server,
             destination,
             name,

--- a/workspace/core/src/events/mod.rs
+++ b/workspace/core/src/events/mod.rs
@@ -10,7 +10,7 @@ mod types;
 mod wal;
 
 pub use audit::{AuditData, AuditEvent, AuditProvider};
-pub use change::ChangeEvent;
+pub use change::{ChangeEvent, ChangeNotification};
 pub use patch::{Patch, PatchFile};
 pub use sync::SyncEvent;
 pub use types::EventKind;

--- a/workspace/server/src/handlers/mod.rs
+++ b/workspace/server/src/handlers/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 use sos_core::{
     commit_tree::CommitProof,
     encode,
-    events::{AuditEvent, AuditProvider, ChangeEvent},
+    events::{AuditEvent, AuditProvider, ChangeNotification},
 };
 
 pub(crate) mod account;
@@ -66,16 +66,14 @@ async fn append_audit_logs<'a>(
     Ok(())
 }
 
-fn send_notifications<'a>(
+fn send_notification<'a>(
     writer: &mut RwLockWriteGuard<'a, State>,
-    notifications: Vec<ChangeEvent>,
+    notification: ChangeNotification,
 ) {
-    // Send notifications on the SSE channel
-    for event in notifications {
-        if let Some(conn) = writer.sse.get(event.address()) {
-            if let Err(_) = conn.tx.send(event) {
-                tracing::debug!("server sent events channel dropped");
-            }
+    // Send notification on the SSE channel
+    if let Some(conn) = writer.sse.get(notification.address()) {
+        if let Err(_) = conn.tx.send(notification) {
+            tracing::debug!("server sent events channel dropped");
         }
     }
 }


### PR DESCRIPTION
So that events are grouped together in a single message; when a patch
containing multiple sync events is applied this will only create a
single notification rather than previously it would send several
notifications which could have caused clients receiving the
notifications to make lots of rapid requests to the server to update
their state.

Now clients can inspect the events in the change notification to
determine what action to take including reducing updates down to a
single server request when possible.

Closes #37.