### PR TITLE
Refactor vault iteration.

### DIFF
--- a/workspace/core/src/audit/log_file.rs
+++ b/workspace/core/src/audit/log_file.rs
@@ -32,7 +32,12 @@ impl AuditLogFile {
 
     /// Get a log file iterator.
     pub fn iter(&self) -> Result<FileIterator<FileRecord>> {
-        Ok(FileIterator::new(&self.file_path, &AUDIT_IDENTITY, false)?)
+        Ok(FileIterator::new(
+            &self.file_path,
+            &AUDIT_IDENTITY,
+            false,
+            None,
+        )?)
     }
 
     /// Create the file used to store audit logs.

--- a/workspace/core/src/file_identity.rs
+++ b/workspace/core/src/file_identity.rs
@@ -9,7 +9,10 @@ pub struct FileIdentity;
 
 impl FileIdentity {
     /// Read the identity magic bytes from a file.
-    pub fn read_file<P: AsRef<Path>>(path: P, identity: &[u8]) -> Result<()> {
+    pub fn read_file<P: AsRef<Path>>(
+        path: P,
+        identity: &[u8],
+    ) -> Result<File> {
         let mut file = File::open(path.as_ref())?;
         let len = file.metadata()?.len();
         if len >= identity.len() as u64 {
@@ -24,7 +27,7 @@ impl FileIdentity {
         } else {
             return Err(Error::IdentityLength);
         }
-        Ok(())
+        Ok(file)
     }
 
     /// Read the identity magic bytes from a slice.

--- a/workspace/core/src/patch.rs
+++ b/workspace/core/src/patch.rs
@@ -164,7 +164,7 @@ impl PatchFile {
 
     /// Get an iterator for the patch file.
     pub fn iter(&self) -> Result<FileIterator<FileRecord>> {
-        FileIterator::new(&self.file_path, &PATCH_IDENTITY, false)
+        FileIterator::new(&self.file_path, &PATCH_IDENTITY, false, None)
     }
 
     /// Count the number of events in the patch file.

--- a/workspace/core/src/wal/file.rs
+++ b/workspace/core/src/wal/file.rs
@@ -284,6 +284,7 @@ impl WalProvider for WalFile {
             &self.file_path,
             &WAL_IDENTITY,
             true,
+            None,
         )?))
     }
 }

--- a/workspace/core/src/wal/mod.rs
+++ b/workspace/core/src/wal/mod.rs
@@ -272,18 +272,6 @@ mod test {
 
         let proof = client.tree().head()?;
 
-        /*
-        println!("client proof root {}", hex::encode(&proof.0));
-        for leaf in client.tree().leaves().unwrap() {
-            println!("client leaf: {}", hex::encode(&leaf));
-        }
-        println!("server proof root {}",
-            hex::encode(server.tree().root().unwrap()));
-        for leaf in server.tree().leaves().unwrap() {
-            println!("server leaf: {}", hex::encode(&leaf));
-        }
-        */
-
         let comparison = server.tree().compare(proof)?;
 
         if let Comparison::Contains(indices, leaves) = comparison {


### PR DESCRIPTION
Use the new generic FileIterator and ensure the encoding supports bi-directional iteration.

Closes #43.