### PR TITLE
Implement switch command in shell client.

### DIFF
--- a/workspace/client/src/account.rs
+++ b/workspace/client/src/account.rs
@@ -48,6 +48,19 @@ pub fn login(
     Ok(FileCache::new(client, cache_dir, true)?)
 }
 
+/// Switch to an account.
+pub fn switch(
+    server: Url,
+    cache_dir: PathBuf,
+    keystore_file: PathBuf,
+) -> Result<FileCache> {
+    if !keystore_file.exists() {
+        return Err(Error::NotFile(keystore_file));
+    }
+    let client = ClientBuilder::new(server, keystore_file).build()?;
+    Ok(FileCache::new(client, cache_dir, true)?)
+}
+
 /// Create a new account.
 pub async fn create_account(
     server: Url,

--- a/workspace/client/src/lib.rs
+++ b/workspace/client/src/lib.rs
@@ -83,8 +83,8 @@ impl ClientBuilder {
 }
 
 pub use account::{
-    create_account, create_signing_key, login, signup, ClientCredentials,
-    ClientKey,
+    create_account, create_signing_key, login, signup, switch,
+    ClientCredentials, ClientKey,
 };
 pub use cache::{ClientCache, FileCache, SyncInfo, SyncKind, SyncStatus};
 pub use client::Client;


### PR DESCRIPTION
So that we can change identity without leaving the shell REPL.

Closes #22.