### PR TITLE
Update mpc-protocol library.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,6 +3391,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpc-protocol"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6eaa5e335e41688f4b2d9fb43442ebf7cbd4fc407c9d13fea4a0c3a6c862cec"
+dependencies = [
+ "async-trait",
+ "binary-stream",
+ "futures",
+ "hex",
+ "http",
+ "log",
+ "pem 3.0.2",
+ "serde",
+ "snow",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5255,7 +5274,7 @@ dependencies = [
  "http",
  "human_bytes",
  "log",
- "mpc-protocol",
+ "mpc-protocol 0.5.0",
  "once_cell",
  "parking_lot",
  "rexpect",
@@ -5498,7 +5517,7 @@ dependencies = [
  "k256",
  "log",
  "mime_guess",
- "mpc-protocol",
+ "mpc-protocol 0.4.1",
  "once_cell",
  "parking_lot",
  "pem 3.0.2",
@@ -5566,7 +5585,7 @@ dependencies = [
  "k256",
  "log",
  "mime_guess",
- "mpc-protocol",
+ "mpc-protocol 0.4.1",
  "once_cell",
  "parking_lot",
  "pem 3.0.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ unicode-width = "0.1"
 parking_lot = "0.12"
 once_cell = "1"
 async-recursion = "1"
-mpc-protocol = "0.4"
+mpc-protocol = "0.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.3.19", features = ["derive", "wrap_help", "env"] }


### PR DESCRIPTION
Adds support for chunked noise protocol communication by splitting a packet into chunks of 65535 so that we respect the limitation of the noise protocol but can transfer arbitrary sized packets.

Each chunk is encrypted/decrypted individually.

See the `Chunk` type in the mpc_protocol library.

Closes #200.