### PR TITLE
Wait for write lock in file transfers shutdown.

### DIFF
--- a/workspace/sdk/src/storage/files/transfer.rs
+++ b/workspace/sdk/src/storage/files/transfer.rs
@@ -289,6 +289,11 @@ impl FileTransfers {
                             let span = span!(Level::DEBUG, "file_transfers");
                             let _enter = span.enter();
                             tracing::debug!("shutdown");
+                            
+                            // Wait for any pending writes to disc
+                            let transfers = queue.read().await;
+                            let _ = transfers.path.lock().await;
+
                             break;
                         }
                     }


### PR DESCRIPTION
Should allow any file transfer write to complete before shutting down the file transfers task.

As we stop the file transfers in `sign_out()` calling `sign_out()` should be enough to perform a graceful shutdown.

Closes #259.