### PR TITLE
Prefer IndexSet for trusted devices.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4092,6 +4092,7 @@ dependencies = [
  "futures",
  "hex",
  "http 1.0.0",
+ "indexmap 2.2.1",
  "once_cell",
  "parking_lot",
  "rand 0.8.5",

--- a/src/commands/device.rs
+++ b/src/commands/device.rs
@@ -59,7 +59,7 @@ pub async fn run(cmd: Command) -> Result<()> {
             let owner = user.read().await;
             let devices = owner.trusted_devices().await?;
 
-            for (_, device) in devices {
+            for device in devices {
                 println!("{}", device.public_id()?);
                 if verbose {
                     println!(

--- a/workspace/net/Cargo.toml
+++ b/workspace/net/Cargo.toml
@@ -77,6 +77,7 @@ futures.workspace = true
 bs58.workspace = true
 urlencoding.workspace = true
 parking_lot.workspace = true
+indexmap.workspace = true
 async-stream = "0.3"
 
 # server

--- a/workspace/net/src/client/account/network_account.rs
+++ b/workspace/net/src/client/account/network_account.rs
@@ -29,7 +29,7 @@ use sos_sdk::{
     vfs, Paths,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -47,6 +47,9 @@ use crate::sdk::account::archive::{Inventory, RestoreOptions};
 
 #[cfg(feature = "device")]
 use crate::sdk::device::{DevicePublicKey, DeviceSigner, TrustedDevice};
+
+#[cfg(feature = "device")]
+use indexmap::IndexSet;
 
 #[cfg(feature = "listen")]
 use crate::client::WebSocketHandle;
@@ -456,9 +459,7 @@ impl Account for NetworkAccount {
     }
 
     #[cfg(feature = "device")]
-    async fn trusted_devices(
-        &self,
-    ) -> Result<HashMap<DevicePublicKey, TrustedDevice>> {
+    async fn trusted_devices(&self) -> Result<IndexSet<TrustedDevice>> {
         let account = self.account.lock().await;
         Ok(account.trusted_devices().await?)
     }

--- a/workspace/sdk/src/account/account.rs
+++ b/workspace/sdk/src/account/account.rs
@@ -38,6 +38,9 @@ use crate::account::archive::{Inventory, RestoreOptions};
 #[cfg(feature = "device")]
 use crate::device::{DevicePublicKey, DeviceSigner, TrustedDevice};
 
+#[cfg(feature = "device")]
+use indexmap::IndexSet;
+
 #[cfg(feature = "search")]
 use crate::storage::search::*;
 
@@ -269,10 +272,7 @@ pub trait Account {
     #[cfg(feature = "device")]
     async fn trusted_devices(
         &self,
-    ) -> std::result::Result<
-        HashMap<DevicePublicKey, TrustedDevice>,
-        Self::Error,
-    >;
+    ) -> std::result::Result<IndexSet<TrustedDevice>, Self::Error>;
 
     /// Public identity information.
     async fn public_identity(
@@ -1369,9 +1369,7 @@ impl Account for LocalAccount {
     }
 
     #[cfg(feature = "device")]
-    async fn trusted_devices(
-        &self,
-    ) -> Result<HashMap<DevicePublicKey, TrustedDevice>> {
+    async fn trusted_devices(&self) -> Result<IndexSet<TrustedDevice>> {
         let storage = self.storage().await?;
         let reader = storage.read().await;
         Ok(reader.devices().clone())

--- a/workspace/sdk/src/device.rs
+++ b/workspace/sdk/src/device.rs
@@ -7,7 +7,11 @@ use crate::{
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{collections::BTreeMap, fmt};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    hash::{Hash, Hasher},
+};
 use time::OffsetDateTime;
 
 /// Device meta data.
@@ -235,6 +239,12 @@ pub struct TrustedDevice {
 impl PartialEq for TrustedDevice {
     fn eq(&self, other: &Self) -> bool {
         self.public_key == other.public_key
+    }
+}
+
+impl Hash for TrustedDevice {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.public_key.as_ref().hash(state);
     }
 }
 

--- a/workspace/sdk/src/storage/server.rs
+++ b/workspace/sdk/src/storage/server.rs
@@ -29,6 +29,9 @@ use crate::{
 #[cfg(feature = "device")]
 use std::collections::HashSet;
 
+#[cfg(feature = "device")]
+use indexmap::IndexSet;
+
 #[cfg(feature = "files")]
 use crate::events::{FileEvent, FileEventLog};
 
@@ -55,7 +58,7 @@ pub struct ServerStorage {
 
     /// Reduced collection of devices.
     #[cfg(feature = "device")]
-    pub(super) devices: HashMap<DevicePublicKey, TrustedDevice>,
+    pub(super) devices: IndexSet<TrustedDevice>,
 
     /// File event log.
     #[cfg(feature = "files")]
@@ -138,8 +141,7 @@ impl ServerStorage {
     #[cfg(feature = "device")]
     async fn initialize_device_log(
         paths: &Paths,
-    ) -> Result<(DeviceEventLog, HashMap<DevicePublicKey, TrustedDevice>)>
-    {
+    ) -> Result<(DeviceEventLog, IndexSet<TrustedDevice>)> {
         let span = span!(Level::DEBUG, "init_device_log");
         let _enter = span.enter();
 
@@ -383,7 +385,7 @@ impl ServerStorage {
 impl ServerStorage {
     /// List the public keys of trusted devices.
     pub fn list_device_keys(&self) -> HashSet<&DevicePublicKey> {
-        self.devices.keys().collect()
+        self.devices.iter().map(|d| d.public_key()).collect()
     }
 
     /// Patch the devices event log.


### PR DESCRIPTION
So that insertion order is maintained.