### PR TITLE
Harden device revoke logic.

### DIFF
--- a/tests/device_revoke/revoke.rs
+++ b/tests/device_revoke/revoke.rs
@@ -71,6 +71,19 @@ async fn device_revoke() -> Result<()> {
         .owner
         .revoke_device(&device_public_key)
         .await?;
+    
+    let revoke_error = enrolled_account.revoke_device(
+        &current_device_public_key).await;
+    
+    if let Err(ClientError::RevokeDeviceSync(mut e)) = revoke_error {
+        let (_, err) = e.errors.remove(0);
+        assert!(matches!(
+            err,
+            ClientError::ResponseJson(StatusCode::FORBIDDEN, _)
+        ));
+    } else {
+        panic!("expecting revoke device sync error");
+    }
 
     // Attempting to sync after the device was revoked
     // yields a forbidden response

--- a/workspace/net/src/client/account/network_account.rs
+++ b/workspace/net/src/client/account/network_account.rs
@@ -154,7 +154,7 @@ impl NetworkAccount {
         // Send the device event logs to the remote servers
         if let Some(e) = self.patch_devices().await {
             tracing::error!(error = ?e);
-            return Err(Error::RevokeDeviceSync);
+            return Err(Error::RevokeDeviceSync(e));
         }
 
         Ok(())

--- a/workspace/net/src/client/error.rs
+++ b/workspace/net/src/client/error.rs
@@ -2,7 +2,7 @@
 use http::StatusCode;
 use serde_json::Value;
 #[cfg(feature = "client")]
-use sos_sdk::sync::Origin;
+use sos_sdk::sync::{Origin, SyncError};
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -71,8 +71,8 @@ pub enum Error {
     RevokeDeviceSelf,
 
     /// Error generated when failing to sync after revoking a device.
-    #[error("failed to sync after revoking device")]
-    RevokeDeviceSync,
+    #[error("failed to sync after revoking device, {0}")]
+    RevokeDeviceSync(SyncError<Error>),
 
     /// Error generated trying to parse a device enrollment sharing URL.
     #[error("invalid share url for device enrollment")]

--- a/workspace/net/src/client/net/http.rs
+++ b/workspace/net/src/client/net/http.rs
@@ -315,7 +315,10 @@ impl SyncClient for HttpClient {
         let account_signature =
             encode_account_signature(self.account_signer.sign(&body).await?)
                 .await?;
-        let auth = bearer_prefix(&account_signature, None);
+        let device_signature =
+            encode_device_signature(self.device_signer.sign(&body).await?)
+                .await?;
+        let auth = bearer_prefix(&account_signature, Some(&device_signature));
         let response = self
             .client
             .patch(url)

--- a/workspace/sdk/src/account/account.rs
+++ b/workspace/sdk/src/account/account.rs
@@ -81,7 +81,7 @@ use tokio::{
 };
 
 /// Result information for a created or updated secret.
-pub struct SecretChange<T> {
+pub struct SecretChange<T: std::error::Error> {
     /// Secret identifier.
     pub id: SecretId,
     /// Event to be logged.
@@ -99,7 +99,7 @@ pub struct SecretChange<T> {
 }
 
 /// Result information for a bulk insert.
-pub struct SecretInsert<T> {
+pub struct SecretInsert<T: std::error::Error> {
     /// Created secrets.
     pub results: Vec<SecretChange<T>>,
     /// Error generated during a sync.
@@ -110,7 +110,7 @@ pub struct SecretInsert<T> {
 }
 
 /// Result information for a secret move event.
-pub struct SecretMove<T> {
+pub struct SecretMove<T: std::error::Error> {
     /// Secret identifier.
     pub id: SecretId,
     /// Event to be logged.
@@ -123,7 +123,7 @@ pub struct SecretMove<T> {
 }
 
 /// Result information for a deleted secret.
-pub struct SecretDelete<T> {
+pub struct SecretDelete<T: std::error::Error> {
     /// Event to be logged.
     pub event: Event,
     /// Commit state of the folder event log before
@@ -139,7 +139,7 @@ pub struct SecretDelete<T> {
 }
 
 /// Result information for folder creation.
-pub struct FolderCreate<T> {
+pub struct FolderCreate<T: std::error::Error> {
     /// Created folder.
     pub folder: Summary,
     /// Event to be logged.
@@ -154,7 +154,7 @@ pub struct FolderCreate<T> {
 }
 
 /// Result information for changes to a folder's attributes.
-pub struct FolderChange<T> {
+pub struct FolderChange<T: std::error::Error> {
     /// Event to be logged.
     pub event: Event,
     /// Commit state before the change.
@@ -167,7 +167,7 @@ pub struct FolderChange<T> {
 }
 
 /// Result information for folder deletion.
-pub struct FolderDelete<T> {
+pub struct FolderDelete<T: std::error::Error> {
     /// Events to be logged.
     pub events: Vec<Event>,
     /// Commit state of the folder.

--- a/workspace/sdk/src/sync/mod.rs
+++ b/workspace/sdk/src/sync/mod.rs
@@ -72,12 +72,21 @@ impl From<Url> for Origin {
 
 /// Error type that can be returned from a sync operation.
 #[derive(Debug)]
-pub struct SyncError<T> {
+pub struct SyncError<T: std::error::Error> {
     /// Errors generated during a sync operation.
     pub errors: Vec<(Origin, T)>,
 }
 
-impl<T> SyncError<T> {
+impl<T: std::error::Error> fmt::Display for SyncError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (_, e) in self.errors.iter() {
+            write!(f, "{}", e)?;
+        }
+        Ok(())
+    }
+}
+
+impl<T: std::error::Error> SyncError<T> {
     /// Convert to an option.
     pub fn into_option(self) -> Option<Self> {
         if self.errors.is_empty() {
@@ -88,7 +97,7 @@ impl<T> SyncError<T> {
     }
 }
 
-impl<T> Default for SyncError<T> {
+impl<T: std::error::Error> Default for SyncError<T> {
     fn default() -> Self {
         Self { errors: Vec::new() }
     }


### PR DESCRIPTION
If a revoked device attempts to revoke another device now yield a forbidden response.

Closes #314.