### PR TITLE
Use rustls-tls-webpki-roots for tokio-tungstenite.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,12 +2914,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
 name = "ouroboros"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3820,19 +3814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pemfile"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3930,15 +3911,6 @@ checksum = "2ed72fbaf78e6f2d41744923916966c4fbe3d7c74e3037a8ee482f1115572603"
 dependencies = [
  "lazy_static",
  "regex",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
-dependencies = [
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4995,11 +4967,11 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tungstenite 0.23.0",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -76,7 +76,7 @@ snow = { version = "0.9", optional = true }
 
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls", "stream"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync"] }
-tokio-tungstenite = { version = "0.23", features = ["rustls-tls-native-roots"] , optional = true}
+tokio-tungstenite = { version = "0.23", features = ["rustls-tls-webpki-roots"] , optional = true}
 
 [dependencies.sos-sdk]
 version = "0.14"


### PR DESCRIPTION
Otherwise on Apple iOS devices connecting to the Let's Encrypt ACME SSL certificate issued to a self-hosted server would error with:

invalid peer certificate: UnknownIssuer

By switching from native roots to bundled webpki roots the issue is fixed and we can now pair devices when using the ACME provider.

See https://github.com/saveoursecrets/crashlog/issues/271