### PR TITLE
Remove `allow(missing_fragment_specifier)`

### DIFF
--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -17,7 +17,6 @@ mod error;
 /// inadvertently written a bad length prefix to stdout.
 #[doc(hidden)]
 #[macro_export]
-#[allow(missing_fragment_specifier)]
 macro_rules! println {
     ($($any:tt)*) => {
         compile_error!("println! macro is forbidden, use eprintln! instead");

--- a/tests/integration/src/test_extension_helper.rs
+++ b/tests/integration/src/test_extension_helper.rs
@@ -13,7 +13,6 @@ use std::{path::PathBuf, sync::Arc};
 use tokio::sync::RwLock;
 
 #[macro_export]
-#[allow(missing_fragment_specifier)]
 macro_rules! println {
     ($($any:tt)*) => {
         compile_error!("println! macro is forbidden, use eprintln! instead");


### PR DESCRIPTION
This lint is `allow`ed in a few places where it doesn't seem to be needed. The `missing_fragment_specifier` lint will be going away in a future version of Rust and replaced with a hard error [1], so update this now to avoid a future `unknown_lints` warning.

[1]: https://github.com/rust-lang/rust/pull/128425