### PR TITLE
Expose `ReadDir` in public API

### DIFF
--- a/crates/vfs/src/memory/mod.rs
+++ b/crates/vfs/src/memory/mod.rs
@@ -18,4 +18,4 @@ pub use fs::{
 };
 pub use meta_data::{FileType, Metadata, Permissions};
 pub use open_options::OpenOptions;
-pub use read_dir::{read_dir, DirEntry};
+pub use read_dir::{read_dir, DirEntry, ReadDir};


### PR DESCRIPTION
Noticed I didn't have access to this, and needed it.